### PR TITLE
Update regexp patterns for telnet

### DIFF
--- a/mb_netmgmt/__main__.py
+++ b/mb_netmgmt/__main__.py
@@ -130,7 +130,7 @@ def get_cli_patterns():
         b"[\r\n\x00\x1b\[K]RP/\d+/(?:RS?P)?\d+\/CPU\d+:[^#]+(?:\([^\)]+\))?#$"
     )  # based on IOS XR driver of Exscript
     patterns.append(
-        b"[\r\n\x00\x1b\[K](?P<text>[\w/ .:,>\(\)\-\?]*)(?P<default>\[[\w/.,():\-]*\])?(?(default)(?P<end1>(?:\?|: ?| |)$)|(?P<end2>: $))"
+        b"[\r\n\x00\x1b\[K]+(?P<text>[A-Z][\w\/ .:,>\(\)\-\?\"]*[^A-Z])(?P<default>\[[\w\/.,():\-]*\])?(?(default)(?P<end1>(?:\?|: ?| |)$)|(?P<end2>: $))"
     )  # Interactive prompt
     patterns.append(b"[\r\n\x00\x1b\[K] --More-- $")  # Terminal paging
     return patterns

--- a/mb_netmgmt/telnet.py
+++ b/mb_netmgmt/telnet.py
@@ -65,7 +65,7 @@ class Handler(StreamRequestHandler, Protocol):
     def read_proxy_response(self):
         prompt_patterns = [self.command_prompt]
         prompt_patterns += get_cli_patterns()
-        _, _, response = self.telnet.expect(prompt_patterns)
+        _, _, response = self.telnet.expect(prompt_patterns, timeout=600)
         return {"response": response.decode()}
 
     def handle_username_prompt(self):

--- a/test/test_mb_netmgmt.py
+++ b/test/test_mb_netmgmt.py
@@ -37,11 +37,17 @@ cli_responses = [
     (b"\rDestination file name (control-c to abort): [running-config]?", True),
     (b"\rDelete net/node0_8_CPU0/disk0:/c12k-mini.vm-4.3.2[confirm]", True),
     (b"\rDestination filename [/net/node0_8_CPU0/disk0:/c12k-mini.vm-4.3.2]?", True),
+    (b"\r\n\rCopy : Destination exists, overwrite ?[confirm]", True),
     (b"\rReload hardware module ? [no,yes] ", True),
     (b"\rDo you wish to continue?[confirm(y/n)]", True),
+    (b'\r\n\r\nFormat will destroy all data on "harddisk:". Continue? [confirm]', True),
     (b"\r --More-- ", True),
     (b"\rSending 5, 100-byte ICMP Echos to 8.8.8.8, timeout is 2 seconds:", False),
     (b"\rProceed with switchover 0/8/CPU0 -> 0/7/CPU0? [confirm]", True),
+    (b"\rPID: SPA-222XXXPOS/RPR, VID: ", False),
+    (b"\rNAME: ", False),
+    (b"\r  Configured hold time: 180, keepalive: ", False),
+    (b"\n\r\n For Address Family: ", False),
 ]
 
 


### PR DESCRIPTION
This request contains several updates that we had to make during the recording of telnet communications with Cisco 12k router.

- **Update of regexp patterns**
While recording of telnet communications we faced some false positive regexp matching that mistakenly considered some output as an end of line

- **Update of test cases**
Relevant test cases from the previous point were added

- **Add timeout for telnet connection**
Explicit timeout for telnet expect method were added. Without it we faced stuck of recording process for some long lasting telnet operations executions