### PR TITLE
added timeout configuration for netconf

### DIFF
--- a/mb_netmgmt/__main__.py
+++ b/mb_netmgmt/__main__.py
@@ -96,14 +96,7 @@ class Protocol:
 
     def get_proxy_config(self):
         """Get the proxy configuration from the current imposter"""
-        imposter_response = requests.get(
-            self.server.callback_url.replace("/_requests", "")
-        )
-        stubs = imposter_response.json()["stubs"]
-        proxy = self.get_proxy(stubs[-1])
-        if not proxy:
-            proxy = self.get_proxy(stubs[0])
-        return proxy
+        return self.proxy
 
     def get_to(self):
         self.key_filename = None
@@ -112,13 +105,13 @@ class Protocol:
                 self.server.callback_url.replace("/_requests", "")
             )
             stubs = imposter_response.json()["stubs"]
-            proxy = self.get_proxy(stubs[-1])
-            if not proxy:
-                proxy = self.get_proxy(stubs[0])
-            if proxy:
-                self.save_key(proxy)
-                disable_algorithms(proxy.get("disabled_algorithms", {}))
-                return parse_to(proxy["to"])
+            self.proxy = self.get_proxy(stubs[-1])
+            if not self.proxy:
+                self.proxy = self.get_proxy(stubs[0])
+            if self.proxy:
+                self.save_key(self.proxy)
+                disable_algorithms(self.proxy.get("disabled_algorithms", {}))
+                return parse_to(self.proxy["to"])
         except (IndexError, AttributeError):
             pass
 

--- a/mb_netmgmt/__main__.py
+++ b/mb_netmgmt/__main__.py
@@ -108,7 +108,13 @@ class Protocol:
     def get_to(self):
         self.key_filename = None
         try:
-            proxy = self.get_proxy_config()
+            imposter_response = requests.get(
+                self.server.callback_url.replace("/_requests", "")
+            )
+            stubs = imposter_response.json()["stubs"]
+            proxy = self.get_proxy(stubs[-1])
+            if not proxy:
+                proxy = self.get_proxy(stubs[0])
             if proxy:
                 self.save_key(proxy)
                 disable_algorithms(proxy.get("disabled_algorithms", {}))

--- a/mb_netmgmt/__main__.py
+++ b/mb_netmgmt/__main__.py
@@ -94,10 +94,6 @@ class Protocol:
         response.raise_for_status()
         return response.json()
 
-    def get_proxy_config(self):
-        """Get the proxy configuration from the current imposter"""
-        return self.proxy
-
     def get_to(self):
         self.key_filename = None
         try:

--- a/mb_netmgmt/__main__.py
+++ b/mb_netmgmt/__main__.py
@@ -24,7 +24,7 @@ import sys
 import tempfile
 import traceback
 from socketserver import BaseServer
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse
 
 import paramiko
 import requests
@@ -105,8 +105,9 @@ class Protocol:
             if not proxy:
                 proxy = self.get_proxy(stubs[0])
             return proxy
-        except (IndexError, AttributeError, requests.RequestException):
-            return None
+        except (IndexError, AttributeError, requests.RequestException) as e:
+            logging.error(f"Failed to get proxy configuration: {e}")
+            raise
 
     def get_to(self):
         self.key_filename = None
@@ -137,16 +138,6 @@ def parse_to(url: str):
     to = urlparse(url)
     if not to.hostname:
         raise ValueError("No hostname")
-    
-    # Parse query parameters to extract timeout if provided
-    # Example: netconf://user:pass@host:830?timeout=300
-    if to.query:
-        query_params = parse_qs(to.query)
-        if 'timeout' in query_params:
-            try:
-                to.timeout = int(query_params['timeout'][0])
-            except (ValueError, IndexError):
-                pass
     
     return to
 

--- a/mb_netmgmt/__main__.py
+++ b/mb_netmgmt/__main__.py
@@ -96,18 +96,14 @@ class Protocol:
 
     def get_proxy_config(self):
         """Get the proxy configuration from the current imposter"""
-        try:
-            imposter_response = requests.get(
-                self.server.callback_url.replace("/_requests", "")
-            )
-            stubs = imposter_response.json()["stubs"]
-            proxy = self.get_proxy(stubs[-1])
-            if not proxy:
-                proxy = self.get_proxy(stubs[0])
-            return proxy
-        except (IndexError, AttributeError, requests.RequestException) as e:
-            logging.error(f"Failed to get proxy configuration: {e}")
-            raise
+        imposter_response = requests.get(
+            self.server.callback_url.replace("/_requests", "")
+        )
+        stubs = imposter_response.json()["stubs"]
+        proxy = self.get_proxy(stubs[-1])
+        if not proxy:
+            proxy = self.get_proxy(stubs[0])
+        return proxy
 
     def get_to(self):
         self.key_filename = None

--- a/mb_netmgmt/netconf.py
+++ b/mb_netmgmt/netconf.py
@@ -71,27 +71,16 @@ class Handler(BaseRequestHandler, Protocol):
         to = self.get_to()
         if not to:
             return
-            
-        # Build connection parameters
-        connect_params = {
+        proxy = self.get_proxy_config()
+        self.manager = connect({
             'host': to.hostname,
             'port': to.port or PORT_NETCONF_DEFAULT,
             'username': to.username,
             'password': to.password,
+            'timeout': getattr(proxy, "timeout", None),
             'key_filename': self.key_filename,
             'hostkey_verify': False,
-        }
-        
-        # Get timeout from proxy configuration if explicitly specified
-        proxy = self.get_proxy_config()
-        if proxy and "timeout" in proxy:
-            try:
-                timeout = int(proxy["timeout"])
-                connect_params['timeout'] = timeout
-            except (ValueError, TypeError):
-                pass
-            
-        self.manager = connect(**connect_params)
+        })
 
     def handle_prompt(self):
         mb_response = self.post_request({"rpc": ""})

--- a/mb_netmgmt/netconf.py
+++ b/mb_netmgmt/netconf.py
@@ -71,7 +71,7 @@ class Handler(BaseRequestHandler, Protocol):
         to = self.get_to()
         if not to:
             return
-        timeout = self.proxy.get("timeout") if self.proxy else None
+        timeout = self.proxy.get("timeout")
         self.manager = connect(
             host=to.hostname,
             port=to.port or PORT_NETCONF_DEFAULT,

--- a/mb_netmgmt/netconf.py
+++ b/mb_netmgmt/netconf.py
@@ -69,17 +69,20 @@ class Handler(BaseRequestHandler, Protocol):
 
     def open_upstream(self):
         to = self.get_to()
+        proxy = self.get_proxy()
         if not to:
             return
-        timeout = getattr(to, "timeout", None)
-        if timeout is None:
-            # Try to get from proxy dict if available
-            if hasattr(self, "proxy") and isinstance(self.proxy, dict):
-                timeout = self.proxy.get("timeout")
+        # Get timeout from proxy configuration
+        timeout = None
+        if isinstance(proxy, dict):
+            timeout = proxy.get('timeout')
+        
+        # Default timeout if none specified
         if timeout is None:
             timeout = 60
         else:
             timeout = int(timeout)
+            
         self.manager = connect(
             host=to.hostname,
             port=to.port or PORT_NETCONF_DEFAULT,

--- a/mb_netmgmt/netconf.py
+++ b/mb_netmgmt/netconf.py
@@ -77,7 +77,7 @@ class Handler(BaseRequestHandler, Protocol):
             'port': to.port or PORT_NETCONF_DEFAULT,
             'username': to.username,
             'password': to.password,
-            'timeout': getattr(proxy, "timeout", None),
+            'timeout': proxy.get("timeout") if proxy else None,
             'key_filename': self.key_filename,
             'hostkey_verify': False,
         })

--- a/mb_netmgmt/netconf.py
+++ b/mb_netmgmt/netconf.py
@@ -89,7 +89,7 @@ class Handler(BaseRequestHandler, Protocol):
                 timeout = int(proxy["timeout"])
                 connect_params['timeout'] = timeout
             except (ValueError, TypeError):
-                pass  # Use ncclient default if invalid timeout
+                pass
             
         self.manager = connect(**connect_params)
 

--- a/mb_netmgmt/netconf.py
+++ b/mb_netmgmt/netconf.py
@@ -71,16 +71,16 @@ class Handler(BaseRequestHandler, Protocol):
         to = self.get_to()
         if not to:
             return
-        proxy = self.get_proxy_config()
-        self.manager = connect({
-            'host': to.hostname,
-            'port': to.port or PORT_NETCONF_DEFAULT,
-            'username': to.username,
-            'password': to.password,
-            'timeout': proxy.get("timeout") if proxy else None,
-            'key_filename': self.key_filename,
-            'hostkey_verify': False,
-        })
+        timeout = self.proxy.get("timeout") if self.proxy else None
+        self.manager = connect(
+            host=to.hostname,
+            port=to.port or PORT_NETCONF_DEFAULT,
+            username=to.username,
+            password=to.password,
+            timeout=timeout,
+            key_filename=self.key_filename,
+            hostkey_verify=False,
+        )
 
     def handle_prompt(self):
         mb_response = self.post_request({"rpc": ""})

--- a/mb_netmgmt/netconf.py
+++ b/mb_netmgmt/netconf.py
@@ -18,8 +18,6 @@
 # along with mb-netmgmt. If not, see <https://www.gnu.org/licenses/
 
 import logging
-import time
-from datetime import datetime
 from socketserver import BaseRequestHandler
 from socketserver import ThreadingTCPServer as Server
 
@@ -54,10 +52,6 @@ class Handler(BaseRequestHandler, Protocol):
         self.session = session
         self.original_transport_read = self.session._transport_read
         self.session._transport_read = self.transport_read
-        
-        # Enhanced: Add operation tracking for timeout analysis
-        self.operation_stats = {}
-        self.long_operation_threshold = 50  # seconds - gateway timeout threshold
 
     def handle(self):
         self.callback_url = self.server.callback_url
@@ -77,22 +71,20 @@ class Handler(BaseRequestHandler, Protocol):
         to = self.get_to()
         if not to:
             return
-        
-        # Get timeout from proxy configuration using existing infrastructure
+            
+        # Get timeout from proxy configuration if available
         timeout = None
         proxy = self.get_proxy_config()
-        
         if proxy and "timeout" in proxy:
             try:
                 timeout = int(proxy["timeout"])
-                logging.info(f"Using timeout from proxy config: {timeout} seconds")
             except (ValueError, TypeError):
-                logging.warning(f"Invalid timeout value in proxy config: {proxy['timeout']}")
+                pass
         
-        # Fallback to default if not found in proxy config
+        # Fallback to extended default for long-running operations (like inventory)
+        # This prevents 504 Gateway Timeout when backend takes 65+ seconds
         if timeout is None:
-            timeout = self._get_enhanced_default_timeout()
-            logging.info(f"Using enhanced default timeout: {timeout} seconds")
+            timeout = 480  # Sufficient for long-running inventory operations
             
         self.manager = connect(
             host=to.hostname,
@@ -103,54 +95,6 @@ class Handler(BaseRequestHandler, Protocol):
             hostkey_verify=False,
             timeout=timeout,
         )
-
-    def _get_enhanced_default_timeout(self):
-        """
-        Enhanced timeout logic for long-running operations
-        Returns appropriate timeout based on potential operation types
-        """
-        # For long-running inventory operations, we need extended timeouts
-        # Based on analysis: Cisco inventory takes ~65 seconds
-        # Gateway timeout is typically ~60 seconds, so we need 480+ seconds for NETCONF
-        return 480  # Sufficient for long-running inventory operations
-    
-    def _detect_operation_type(self, request_data):
-        """
-        Detect operation type from NETCONF request to provide insights
-        """
-        if not request_data or 'rpc' not in request_data:
-            return 'unknown'
-            
-        rpc_str = str(request_data['rpc']).lower()
-        
-        if 'inventory' in rpc_str:
-            if 'cisco' in rpc_str or 'ios-xr' in rpc_str:
-                return 'cisco_inventory'
-            return 'inventory'
-        elif 'get-config' in rpc_str:
-            return 'config_get' 
-        elif 'edit-config' in rpc_str:
-            return 'config_edit'
-        elif '<get>' in rpc_str:
-            return 'get_operation'
-            
-        return 'default'
-    
-    def _log_operation_timing(self, operation_id, duration, operation_type):
-        """
-        Log operation timing with gateway timeout analysis
-        """
-        if duration > self.long_operation_threshold:
-            logging.warning(f"⚠️  Long operation detected: {operation_id}")
-            logging.warning(f"   Type: {operation_type}, Duration: {duration:.1f}s")
-            logging.warning(f"   This exceeds typical gateway timeout (~60s)")
-            
-            if operation_type == 'cisco_inventory':
-                logging.info("💡 Cisco inventory operations typically take 65-70s")
-                logging.info("   This may cause 504 Gateway Timeout in upstream systems")
-                logging.info("   Consider using async polling or extended timeouts")
-        
-        logging.info(f"✅ NETCONF operation {operation_id} completed in {duration:.1f}s")
 
     def handle_prompt(self):
         mb_response = self.post_request({"rpc": ""})
@@ -184,50 +128,7 @@ class Handler(BaseRequestHandler, Protocol):
         return {"rpc-reply": remove_message_id(self.rpc_reply._root)}
 
     def send_upstream(self, request, request_id):
-        # Enhanced: Track operation timing for analysis
-        operation_id = f"netconf_{request_id}_{int(time.time())}"
-        start_time = time.time()
-        
-        # Detect operation type for analysis
-        operation_type = self._detect_operation_type(request)
-        
-        logging.info(f"🔄 Starting NETCONF operation {operation_id} ({operation_type})")
-        
-        # Store operation info
-        self.operation_stats[operation_id] = {
-            'start_time': start_time,
-            'request_id': request_id,
-            'operation_type': operation_type,
-            'start_datetime': datetime.now().isoformat()
-        }
-        
-        try:
-            # Execute the original operation
-            self.rpc_reply = self.manager.rpc(to_ele(request["rpc"]))
-            
-            # Record successful completion
-            duration = time.time() - start_time
-            self.operation_stats[operation_id]['duration'] = duration
-            self.operation_stats[operation_id]['success'] = True
-            
-            # Log timing analysis
-            self._log_operation_timing(operation_id, duration, operation_type)
-            
-        except Exception as e:
-            # Record failure
-            duration = time.time() - start_time
-            self.operation_stats[operation_id]['duration'] = duration
-            self.operation_stats[operation_id]['success'] = False
-            self.operation_stats[operation_id]['error'] = str(e)
-            
-            logging.error(f"❌ NETCONF operation {operation_id} failed after {duration:.1f}s: {e}")
-            raise
-        
-        # Clean up old stats (keep last 50 operations)
-        if len(self.operation_stats) > 50:
-            oldest_key = min(self.operation_stats.keys(), 
-                           key=lambda k: self.operation_stats[k]['start_time'])
-            del self.operation_stats[oldest_key]
+        self.rpc_reply = self.manager.rpc(to_ele(request["rpc"]))
 
     def respond(self, response, request_id):
         reply = response.get("rpc-reply", f'<rpc-reply xmlns="{BASE_NS_1_0}"/>')


### PR DESCRIPTION
Respects timeout from proxy configuration when available
Falls back to extended default (480s) when no timeout is specified
Handles invalid timeout values gracefully by falling back to default